### PR TITLE
Add block.json and update block registration

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -49,39 +49,13 @@ class PromptManagerBlocks {
             return;
         }
         
-        // Register Prompt Display Block
-        register_block_type('prompt-manager/prompt-display', array(
-            'editor_script' => 'prompt-manager-blocks',
-            'editor_style'  => 'prompt-manager-blocks-editor',
-            'style'         => 'prompt-manager-blocks',
-            'attributes'    => array(
-                'promptId' => array(
-                    'type' => 'number',
-                    'default' => 0,
-                ),
-                'showTitle' => array(
-                    'type' => 'boolean',
-                    'default' => true,
-                ),
-                'showExcerpt' => array(
-                    'type' => 'boolean',
-                    'default' => true,
-                ),
-                'showImage' => array(
-                    'type' => 'boolean',
-                    'default' => true,
-                ),
-                'imageSize' => array(
-                    'type' => 'string',
-                    'default' => 'medium',
-                ),
-                'alignment' => array(
-                    'type' => 'string',
-                    'default' => 'none',
-                ),
-            ),
-            'render_callback' => array($this, 'render_prompt_display_block'),
-        ));
+        // Register Prompt Display Block using metadata
+        register_block_type(
+            PROMPT_MANAGER_PLUGIN_DIR . 'src/block.json',
+            array(
+                'render_callback' => array($this, 'render_prompt_display_block'),
+            )
+        );
         
         // Register Prompt Gallery Block
         register_block_type('prompt-manager/prompt-gallery', array(

--- a/src/block.json
+++ b/src/block.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": 2,
+  "name": "prompt-manager/prompt-display",
+  "title": "Prompt Display",
+  "category": "prompt-manager",
+  "icon": "lightbulb",
+  "editorScript": "file:../build/blocks.js",
+  "style": "file:../assets/css/blocks.css",
+  "editorStyle": "file:../assets/css/blocks-editor.css"
+}


### PR DESCRIPTION
## Summary
- define metadata for Prompt Display block in `block.json`
- use metadata file when registering the block in PHP

## Testing
- `npm run build`
- `php -l includes/blocks.php`

------
https://chatgpt.com/codex/tasks/task_e_68875a26cb10833389bef519195180a9