### PR TITLE
Regenerate WordPress block asset dependencies

### DIFF
--- a/build/blocks.asset.php
+++ b/build/blocks.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array(), 'version' => 'a07b0c2691c071208602');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n'), 'version' => '2a5eb3ea25d7518ee86d');

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,16 @@
-(function () {
-  const { registerBlockType } = wp.blocks;
-  const { createElement, Fragment } = wp.element;
-  const { InspectorControls, useBlockProps } = wp.blockEditor;
-  const { PanelBody, SelectControl, ToggleControl, RangeControl, TextControl, ColorPicker } =
-    wp.components;
-  const { __ } = wp.i18n;
-  const { select } = wp.data;
+import { registerBlockType } from '@wordpress/blocks';
+import { createElement, Fragment } from '@wordpress/element';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+  PanelBody,
+  SelectControl,
+  ToggleControl,
+  RangeControl,
+  TextControl,
+  ColorPicker,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
 
   // Prompt Display Block
   registerBlockType('prompt-manager/prompt-display', {
@@ -484,4 +489,3 @@
       return null; // Rendered by PHP
     },
   });
-})();


### PR DESCRIPTION
## Summary
- convert block code to ES modules so dependency extraction works
- regenerate `build/blocks.asset.php`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68875a2bbf048333a827b5a2a98adb00