### PR TITLE
Fix missing settings defaults

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -53,7 +53,9 @@ class PromptManagerSettings {
             'enable_real_time_protection' => true,
             'protection_level' => 'maximum',
             'modal_blur_intensity' => 25,
-            'content_blur_intensity' => 20
+            'content_blur_intensity' => 20,
+            'debug_mode' => false,
+            'performance_mode' => 'balanced'
         );
         
         $existing_options = get_option($this->option_name, array());

--- a/prompt-manager.php
+++ b/prompt-manager.php
@@ -60,7 +60,6 @@ class PromptManager {
         add_action('wp_ajax_reset_prompt_settings', array($this, 'ajax_reset_prompt_settings'));
         add_action('wp_ajax_get_blur_status', array($this, 'ajax_get_blur_status'));
         add_action('wp_ajax_stop_blur_processing', array($this, 'ajax_stop_blur_processing'));
-        add_action('wp_ajax_save_prompt_settings', array($this, 'ajax_save_prompt_settings'));
         add_action('wp_ajax_process_blur_batch', array($this, 'ajax_process_blur_batch'));
         add_action('wp_ajax_get_analytics_data', array($this, 'ajax_get_analytics_data'));
         


### PR DESCRIPTION
## Summary
- define debug and performance defaults in `PromptManagerSettings`
- remove duplicate `save_prompt_settings` AJAX registration

## Testing
- `npm run build`
- `npm test` *(fails: "no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6887587c5504833385959c5e28096680